### PR TITLE
fix: replace \/\ with \newine

### DIFF
--- a/content/docs/concepts/consensus/protocol.md
+++ b/content/docs/concepts/consensus/protocol.md
@@ -140,7 +140,7 @@ and if the validator's timer has expired in the precommit step, its initial valu
 
 $$
 b = \begin{cases}
-1 & \text{if timer expired in prepare step,} \\
+1 & \text{if timer expired in prepare step,} \newline
 0 & \text{if timer expired in precommit step.}
 \end{cases}
 $$
@@ -149,8 +149,8 @@ In the next rounds, each validator select $2f+1$ properly justified main-votes f
 
 $$
 b = \begin{cases}
-0 & \text{if there is a main-vote for 0,} \\
-1 & \text{if there is a main-vote for 1,} \\
+0 & \text{if there is a main-vote for 0,} \newline
+1 & \text{if there is a main-vote for 1,} \newline
 0 (biased) & \text{if all main-votes are abstain.}
 \end{cases}
 $$
@@ -177,8 +177,8 @@ The main-vote value $v$ determine as below:
 
 $$
 v = \begin{cases}
-0 & \text{if there are 2f+1 pre-vote for 0,} \\
-1 & \text{if there are 2f+1 pre-vote for 1,} \\
+0 & \text{if there are 2f+1 pre-vote for 0,} \newline
+1 & \text{if there are 2f+1 pre-vote for 1,} \newline
 abstain & \text{if there are pre-votes for 0 and 1.}
 \end{cases}
 $$

--- a/content/docs/concepts/consensus/sortition.md
+++ b/content/docs/concepts/consensus/sortition.md
@@ -38,13 +38,13 @@ The pseudocode below demonstrates the evaluation of the VRF for the sortition al
 
 $$
 \begin{align*}
-& \textbf{function} \ VRF(sk, seed, total\_stake) \\
-& \qquad pk \gets P_{BLS}(sk) \\
-& \qquad proof \gets S_{BLS}(sk, seed \| pk) \\
-& \qquad rnd \gets H(proof) \\
-& \qquad index \gets \frac{(rnd \times total\_stake)}{2^{256}} \\
-& \qquad \\
-& \qquad \textbf{return} \ index, proof \\
+& \textbf{function} \ VRF(sk, seed, total\_stake) \newline
+& \qquad pk \gets P_{BLS}(sk) \newline
+& \qquad proof \gets S_{BLS}(sk, seed \| pk) \newline
+& \qquad rnd \gets H(proof) \newline
+& \qquad index \gets \frac{(rnd \times total\_stake)}{2^{256}} \newline
+& \qquad \newline
+& \qquad \textbf{return} \ index, proof \newline
 & \textbf{end function}
 \end{align*}
 $$
@@ -63,15 +63,15 @@ To verify a sortition proof, both the validator's public key and stake are requi
 
 $$
 \begin{align*}
-& \textbf{function} \ verifyVRF(pk, seed, proof, stake, total\_stake) \\
-& \qquad \textbf{if} \ V_{BLS}(pk, seed \| pk, proof) = True \ \textbf{then} \\
-& \qquad \qquad rnd \gets H(proof) \\
-& \qquad \qquad index \gets \frac{(rnd \times total\_stake)}{2^{256}} \\
-& \qquad \\
-& \qquad  \qquad \textbf{return} \ index \leqslant stake \\
-& \qquad  \textbf{else} \\
-& \qquad  \qquad \textbf{return} \ False \\
-& \qquad  \textbf{end if} \\
+& \textbf{function} \ verifyVRF(pk, seed, proof, stake, total\_stake) \newline
+& \qquad \textbf{if} \ V_{BLS}(pk, seed \| pk, proof) = True \ \textbf{then} \newline
+& \qquad \qquad rnd \gets H(proof) \newline
+& \qquad \qquad index \gets \frac{(rnd \times total\_stake)}{2^{256}} \newline
+& \qquad \newline
+& \qquad  \qquad \textbf{return} \ index \leqslant stake \newline
+& \qquad  \textbf{else} \newline
+& \qquad  \qquad \textbf{return} \ False \newline
+& \qquad  \textbf{end if} \newline
 & \textbf{end function}
 \end{align*}
 $$
@@ -94,8 +94,8 @@ In each block, the block proposer generates a new sortition seed based on the pr
 
 $$
 \begin{align*}
-& \textbf{function} \ generateSeed(sk, prev\_seed) \\
-& \qquad \textbf{return} \ S_{BLS}(sk, H(prev\_seed)) \\
+& \textbf{function} \ generateSeed(sk, prev\_seed) \newline
+& \qquad \textbf{return} \ S_{BLS}(sk, H(prev\_seed)) \newline
 & \textbf{end function}
 \end{align*}
 $$
@@ -106,8 +106,8 @@ The verification function is as follows:
 
 $$
 \begin{align*}
-& \textbf{function} \ verifySeed(pk, prev\_seed, seed) \\
-& \qquad \textbf{return} \ V_{BLS}(pk, H(prev\_seed), seed) \\
+& \textbf{function} \ verifySeed(pk, prev\_seed, seed) \newline
+& \qquad \textbf{return} \ V_{BLS}(pk, H(prev\_seed), seed) \newline
 & \textbf{end function}
 \end{align*}
 $$

--- a/content/docs/concepts/transaction/fee.md
+++ b/content/docs/concepts/transaction/fee.md
@@ -11,33 +11,16 @@ The percentage, minimum fee, and maximum fee parameters are part of the blockcha
 
 The formula to calculate the transaction fee is as follows:
 
-<!--
 $$
 \begin{align*}
-& \textbf{function} \ calculateFee(amount, percentage, fee_{min}, fee_{max}) \\
-& \qquad fee \gets amount \times percentage \\
-& \\
-& \qquad \textbf{if} \ fee < fee_{min} \ \textbf{then} \\
-& \qquad \qquad \textbf{return} \ fee_{min} \\
-& \\
-& \qquad \textbf{if} \ fee > fee_{max} \ \textbf{then} \\
-& \qquad \qquad \textbf{return} \ fee_{max} \\
-& \\
-& \qquad \textbf{return} \ fee \\
-& \textbf{end function}
-\end{align*}
-$$ -->
-
-$$
-\begin{align*}
-fee = amount \times percentage \\
-\\
+fee = amount \times percentage \newline
+\newline
 fee =
 \begin{cases}
- & fee_{min} & \textbf{ if } \ fee < fee_{min} \\
-  & \\
- & fee_{max} & \textbf{ if } \ fee > fee_{max} \\
- & \\
+ & fee_{min} & \textbf{ if } \ fee < fee_{min} \newline
+  & \newline
+ & fee_{max} & \textbf{ if } \ fee > fee_{max} \newline
+ & \newline
  & fee & \textbf{otherwise}
  \end{cases}
 \end{align*}


### PR DESCRIPTION
This PR replaces `\\` with `\newline` in math formulas.