### PR TITLE
chore: remove preface heading from pages

### DIFF
--- a/.mdlrc.rb
+++ b/.mdlrc.rb
@@ -24,5 +24,5 @@ exclude_rule 'MD033'
 # First line in file should be a top level header
 exclude_rule 'MD041'
 
+# Allow Multiple headers with the same content
 exclude_rule 'MD024'
-exclude_rule 'MD029'

--- a/content/get-started/become-a-validator.md
+++ b/content/get-started/become-a-validator.md
@@ -13,7 +13,8 @@ they are self-elected through a randomization algorithm based on their stake and
 
 ## What Roles do Validators Play?
 
-Validators can run Pactus Core software on their personal computers or remote servers to process transactions, create blocks,
+Validators can run Pactus Core software on their personal computers or
+remote servers to process transactions, create blocks,
 and uphold network security and decentralization.
 By staking their own coins, validators contribute to the network's security and are rewarded for their efforts.
 

--- a/content/get-started/configuration.md
+++ b/content/get-started/configuration.md
@@ -3,8 +3,6 @@ title: Pactus Node Configuration
 weight: 6
 ---
 
-## Preface
-
 The Pactus node can be configured using a [TOML](https://toml.io/en/) file,
 which is a simple text format for configuration.
 This file is automatically created when the node initializes.

--- a/content/get-started/pactus-daemon.md
+++ b/content/get-started/pactus-daemon.md
@@ -3,8 +3,6 @@ title: Run Pactus in Command Line Mode
 weight: 3
 ---
 
-## Preface
-
 Pactus can be run in different modes, including the command-line interface (CLI) and the graphical user interface (GUI).
 This tutorial will guide you through the steps to run Pactus in CLI mode, suitable for advanced users.
 

--- a/content/get-started/pactus-docker.md
+++ b/content/get-started/pactus-docker.md
@@ -3,8 +3,6 @@ title: Run Pactus using Docker
 weight: 4
 ---
 
-## Preface
-
 Docker is a tool that simplifies the process of creating, deploying, and running applications using containers.
 With containers, developers can bundle all the necessary parts of an application, including libraries and dependencies,
 and deploy them as a single package.

--- a/content/get-started/pactus-gui.md
+++ b/content/get-started/pactus-gui.md
@@ -3,8 +3,6 @@ title: Run Pactus in Graphic Mode
 weight: 2
 ---
 
-## Preface
-
 Pactus can be run in different modes, including the command-line interface (CLI) and the graphical user interface (GUI).
 This tutorial will guide you through the steps to run Pactus in GUI mode, suitable for beginner to advanced users.
 

--- a/content/tutorials/grpc-basic-auth.md
+++ b/content/tutorials/grpc-basic-auth.md
@@ -3,8 +3,6 @@ title: Secure gRPC Using Basic Authentication
 weight: 6
 ---
 
-## Preface
-
 The Pactus Blockchain offers a gRPC interface, enabling users to interact with the blockchain
 and its native wallet. To enhance the security of gRPC APIs, we have implemented a Basic Authentication
 mechanism based on [bcrypt](https://en.wikipedia.org/wiki/Bcrypt) password hashing.
@@ -77,12 +75,12 @@ To enable Basic Authentication in your Pactus Blockchain configuration, follow t
 1. Open the [configuration](https://docs.pactus.org/get-started/configuration/) file in your Pactus directory.
 2. Insert the generated user with the hashed password into the `basic_auth` field in the `grpc` section:
 
-```toml
-[grpc]
-enable = true
-enable_wallet = false
-listen = "127.0.0.1:50051"
-basic_auth = "user:$2a$10$nl6VKEzSENIK5dmzoADgKeTFtCusQxeVCZiXkRzzbyfG.bLpHtrda"
-```
+   ```toml
+   [grpc]
+   enable = true
+   enable_wallet = false
+   listen = "127.0.0.1:50051"
+   basic_auth = "user:$2a$10$nl6VKEzSENIK5dmzoADgKeTFtCusQxeVCZiXkRzzbyfG.bLpHtrda"
+   ```
 
 3. Restart or run the node to apply this configuration.

--- a/content/tutorials/grpc-sign-transactions.md
+++ b/content/tutorials/grpc-sign-transactions.md
@@ -3,8 +3,6 @@ title: Sign Transactions Using gRPC
 weight: 5
 ---
 
-## Preface
-
 The Pactus Blockchain provides a gRPC interface that allows users to interact with the blockchain and native wallet.
 This is ideal for merchants and users who want to create, sign, and broadcast transactions using their local node.
 This tutorial will guide you step-by-step on how to use gRPC to sign transactions.

--- a/content/tutorials/integration-guide.md
+++ b/content/tutorials/integration-guide.md
@@ -3,8 +3,6 @@ title: Pactus Integration Guide
 weight: 14
 ---
 
-## Preface
-
 This guide is intended for developers and infrastructure teams who want to connect
 their applications directly to the Pactus network, including wallets, exchanges,
 analytics platforms, staking services, and custom backend systems.

--- a/content/tutorials/linux-systemd.md
+++ b/content/tutorials/linux-systemd.md
@@ -3,8 +3,6 @@ title: Run Pactus as a Systemd Service
 weight: 11
 ---
 
-## Preface
-
 [Systemd](https://en.wikipedia.org/wiki/Systemd) is a system and service manager for Linux that
 helps manage how programs start up, run, and shut down.
 It also handles system processes, logging, and basic service monitoring.

--- a/content/tutorials/pactus-metrics.md
+++ b/content/tutorials/pactus-metrics.md
@@ -3,8 +3,6 @@ title: Run Pactus Metrics
 weight: 10
 ---
 
-## Preface
-
 Pactus can be run with metrics, providing you with the ability to monitor your node.
 This tutorial will guide you through the steps to run Pactus with metrics, suitable for advanced users.
 

--- a/content/tutorials/pactus-testnet.md
+++ b/content/tutorials/pactus-testnet.md
@@ -3,8 +3,6 @@ title: Join Pactus Testnet
 weight: 15
 ---
 
-## Preface
-
 The Pactus testnet is a public testing environment that replicates the
 functionality of the mainnet but uses test coins with no real-world value.
 Running a node on the testnet allows you to experiment safely, test applications,

--- a/content/tutorials/pactus-wallet.md
+++ b/content/tutorials/pactus-wallet.md
@@ -3,8 +3,6 @@ title: Use Pactus Wallet
 weight: 2
 ---
 
-## Preface
-
 The Pactus Blockchain provides a wallet application that allows users to interact with the Pactus blockchain
 without the need to run a node.
 This is ideal for users who do not wish to operate a node but still want to create a personal wallet to manage their funds.

--- a/content/tutorials/pruned-nodes.md
+++ b/content/tutorials/pruned-nodes.md
@@ -3,8 +3,6 @@ title: Running a Pruned Node
 weight: 4
 ---
 
-## Preface
-
 The Pactus Blockchain supports pruned nodes to help users manage storage efficiently by retaining only
 the most recent and relevant data. This tutorial will guide you step-by-step on how to prune your node,
 whether using the command line or the graphical interface.

--- a/content/tutorials/reduce-network.md
+++ b/content/tutorials/reduce-network.md
@@ -3,8 +3,6 @@ title: Reduce Network Usage
 weight: 9
 ---
 
-## Preface
-
 Pactus is designed for low traffic usage.
 However, some users still face bandwidth limitations imposed by their Internet Service Providers (ISPs).
 This guide will explore effective ways to reduce network usage for a Pactus node.

--- a/content/tutorials/secure-connections.md
+++ b/content/tutorials/secure-connections.md
@@ -3,8 +3,6 @@ title: Secure Connections
 weight: 7
 ---
 
-## Preface
-
 As the Pactus blockchain grows, the need for individuals and merchants to
 communicate and interact with Pactus nodes is increasing.
 Pactus provides several communication protocols,

--- a/content/tutorials/send-transaction-gui.md
+++ b/content/tutorials/send-transaction-gui.md
@@ -3,8 +3,6 @@ title: Send Transactions in Graphic Mode
 weight: 1
 ---
 
-## Preface
-
 The Pactus Blockchain offers a Graphical User Interface (GUI) that comes with a built-in wallet to create,
 sign and broadcast transactions.
 This tutorial aims to guide you step-by-step on how to use the GUI application to send transactions to the Pactus blockchain.

--- a/content/tutorials/software-verification.md
+++ b/content/tutorials/software-verification.md
@@ -3,8 +3,6 @@ title: Verify Pactus Software Is Safe
 weight: 12
 ---
 
-## Preface
-
 When downloading Pactus software, it's important to verify that the binaries are authentic and
 haven't been tampered with.
 By verifying the signatures of the files, you ensure that the software you're installing is secure.

--- a/content/tutorials/zero-fee-transactions.md
+++ b/content/tutorials/zero-fee-transactions.md
@@ -3,8 +3,6 @@ title: Send Zero-Fee Transactions
 weight: 13
 ---
 
-## Preface
-
 Pactus supports zero-fee transactions starting from
 [Version 1.6.0 (Mumbai)](https://pactus.org/2024/11/14/pactus-1.6.0-mumbai-released/).
 However, for security reasons, there are restrictions on zero-fee transactions:


### PR DESCRIPTION
## Summary

Removes the `## Preface` heading from 17 documentation pages across `content/get-started/` and `content/tutorials/`.

## Reason

The `## Preface` heading is a meta-label rather than descriptive content. Introductory paragraphs work better as un-headed text flowing naturally after the frontmatter, which is the standard documentation convention.

## Changes

- Removed `## Preface` and the following blank line from 17 files
- Fixed an MD029 markdownlint issue in `grpc-basic-auth.md` (code block indentation within ordered list)